### PR TITLE
Fix installation tests

### DIFF
--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -27,4 +27,4 @@ jobs:
     - name: Install package
       run: pip install -e .
     - name: Test module load
-      run: python -c "import {{cookiecutter.repo_name_slug}}"
+      run: python -c "import stavisky_lab_to_nwb"


### PR DESCRIPTION
@felixp8 Our CI semi-regularly tests if these kinds of packages are at least installable

There was a bug though - I believe it was fixed on the upstream cookiecutter so should be isolated here